### PR TITLE
fix(parser): allow timekeeper name to have dots

### DIFF
--- a/ledes_parser/grammars/spec_98B/main_grammar.lark
+++ b/ledes_parser/grammars/spec_98B/main_grammar.lark
@@ -99,9 +99,8 @@ BILLING_END_DATE: YYYYMMDD
 INVOICE_DESCRIPTION: /[a-zA-Z0-9 _\-'\.]+/
 BILLING_CONTACT: /[a-zA-Z0-9 _\-]+/
 CLIENT_MATTER_ID: /[A-Z0-9\-]+/
-TIMEKEEPER_NAME: /[a-zA-Z0-9 _\-\,']+/
+TIMEKEEPER_NAME: /[a-zA-Z0-9 _\-\,'\.]+/
 TIMEKEEPER_CLASSIFICATION: /[a-zA-Z0-9 _\-]+/
-TIMEKEEPER_HOURLY_RATE: /\d+(\.\d{2})?/
 
 _PIPE: "|"
 _LINE_ENDING: "[]" // Every line has to end with []

--- a/tests/unit/test_ledes_98B_parser.py
+++ b/tests/unit/test_ledes_98B_parser.py
@@ -7,6 +7,16 @@ class TestLedes98BParser(unittest.TestCase):
     def setUp(self):
         self.parser = get_parser(spec="98B")
 
+    def test_can_parse_timekeeper_name_with_dots(self):
+        data = """
+LEDES1998B[]
+INVOICE_DATE|INVOICE_NUMBER|CLIENT_ID|LAW_FIRM_MATTER_ID|INVOICE_TOTAL|BILLING_START_DATE|BILLING_END_DATE|INVOICE_DESCRIPTION|LINE_ITEM_NUMBER|EXP/FEE/INV_ADJ_TYPE|LINE_ITEM_NUMBER_OF_UNITS|LINE_ITEM_ADJUSTMENT_AMOUNT|LINE_ITEM_TOTAL|LINE_ITEM_DATE|LINE_ITEM_TASK_CODE|LINE_ITEM_EXPENSE_CODE|LINE_ITEM_ACTIVITY_CODE|TIMEKEEPER_ID|LINE_ITEM_DESCRIPTION|LAW_FIRM_ID|LINE_ITEM_UNIT_COST|TIMEKEEPER_NAME|TIMEKEEPER_CLASSIFICATION|CLIENT_MATTER_ID[]
+19990225|96542|555|555.900|1053|19990101|19990131|For services rendered|1|F|2.00|-70|630|19990115|L510||A102|22547|Research Attorney's fees, Set off claim|24-6437381|350|Arnsley, Robert Sr.|PARTNR|423-987[]
+"""
+        result = self.parser.parse(data)
+        self.assertIsNotNone(result)
+        self.assertIn("Arnsley, Robert Sr.", result.pretty())
+
     def test_can_parse_invoice_total_with_zero_to_four_decimals(self):
         data = """
 LEDES1998B[]


### PR DESCRIPTION
Allow dots in timekeeper name. "Arnsley, Robert Sr.", for example.