### PR TITLE
Refactor/shorten import syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # ledes-parser
-A package for parsing LEDES format files. 
+A package for parsing LEDES format files.
 
-Note: this is a WIP. DO NOT RELY ON THIS FOR YOUR LEGAL INVOICING.
+## Warning
+This is very much a work in progress. DO NOT RELY ON THIS FOR YOUR LEGAL INVOICING.
 
 ## Installation
 
@@ -12,7 +13,7 @@ pip install ledes-parser
 ```
 # Example Usage
 ```python
-from ledes_parser.ledes_parser import get_parser
+from ledes_parser import get_parser
 
 with open('path/to/the/ledes_file.txt', 'r') as f:
     ledes_data = f.read()

--- a/ledes_parser/__init__.py
+++ b/ledes_parser/__init__.py
@@ -1,1 +1,7 @@
+from .ledes_parser import get_parser
+
 __version__ = "0.0.1"
+
+__all__ = [
+    "get_parser",
+]

--- a/tests/unit/test_get_parser.py
+++ b/tests/unit/test_get_parser.py
@@ -1,10 +1,10 @@
 import pytest
 
+from ledes_parser import get_parser
 from ledes_parser.ledes_parser import (
     SUPPORTED_SPECS,
     UnrecognizedLEDESVersionError,
     UnsupportedLEDESVersionError,
-    get_parser,
 )
 
 

--- a/tests/unit/test_ledes_98B_parser.py
+++ b/tests/unit/test_ledes_98B_parser.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ledes_parser.ledes_parser import get_parser
+from ledes_parser import get_parser
 
 
 class LEDES1998BBuilder:

--- a/tests/unit/test_parse_98B_text.py
+++ b/tests/unit/test_parse_98B_text.py
@@ -7,7 +7,7 @@ import pytest
 from faker import Faker
 from lark import Lark
 
-from ledes_parser.ledes_parser import get_parser
+from ledes_parser import get_parser
 from tests.conftest import InvoiceDataFaker
 
 


### PR DESCRIPTION
...so the import can just be `from ledes_parser import get_parser` instead of `from ledes_parser.ledes_parser import get_parser`.