### PR TITLE
build: fix accidental setup-time dependencies

### DIFF
--- a/ledes_parser/__init__.py
+++ b/ledes_parser/__init__.py
@@ -1,6 +1,6 @@
-from .ledes_parser import get_parser
-
 __version__ = "0.0.1"
+
+from .ledes_parser import get_parser
 
 __all__ = [
     "get_parser",

--- a/ledes_parser/ledes_parser.py
+++ b/ledes_parser/ledes_parser.py
@@ -24,7 +24,7 @@ class UnsupportedLEDESVersionError(NotImplementedError):
     pass
 
 
-def get_parser(spec: SupportedSpecs, ast_only: bool = False) -> "Lark":
+def get_parser(spec: SupportedSpecs, ast_only: bool = False) -> Lark:
     """
     @returns A parser that can read ledes text in the given ledes spec (e.g., 1998B, 1998BI, etc...).
     @param ast_only: Whether the parser should return just the abstract syntax tree, instead of mapping the tokens to a dict.

--- a/ledes_parser/ledes_parser.py
+++ b/ledes_parser/ledes_parser.py
@@ -4,7 +4,7 @@ import pkg_resources
 from lark import Lark
 from lark.visitors import merge_transformers
 
-from ledes_parser.transformers.transformer_1998B import (
+from .transformers import (
     LEDES1998BTransformer,
     LineItemTransformer,
 )
@@ -24,7 +24,7 @@ class UnsupportedLEDESVersionError(NotImplementedError):
     pass
 
 
-def get_parser(spec: SupportedSpecs, ast_only: bool = False) -> Lark:
+def get_parser(spec: SupportedSpecs, ast_only: bool = False) -> "Lark":
     """
     @returns A parser that can read ledes text in the given ledes spec (e.g., 1998B, 1998BI, etc...).
     @param ast_only: Whether the parser should return just the abstract syntax tree, instead of mapping the tokens to a dict.

--- a/ledes_parser/transformers/__init__.py
+++ b/ledes_parser/transformers/__init__.py
@@ -1,0 +1,3 @@
+from .transformer_1998B import LEDES1998BTransformer, LineItemTransformer
+
+__all__ = ["LEDES1998BTransformer", "LineItemTransformer"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 
-pre-commit
-ruff
+pre-commit==3.7.1
+ruff==0.5.3

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 
-pytest
-faker
+pytest==8.2.2
+faker==26.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+lark==1.1.9
 lark-parser==0.12.0

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,34 @@
+import os
+
 from setuptools import find_packages, setup
 
 
-def main() -> None:
-    import ledes_parser as app
+# To avoid needless setup-time dependencies introduced as a side-effect of importing the __init__.py file, for now.
+def read_version():
+    version_file_path = os.path.join(
+        os.path.dirname(__file__), "ledes_parser", "__init__.py"
+    )
+    with open(version_file_path) as f:
+        for line in f:
+            if line.startswith("__version__"):
+                # Extract the version number.
+                delim = '"' if '"' in line else "'"
+                return line.split(delim)[1]
+    raise RuntimeError("Unable to find version string.")
 
+
+def main() -> None:
     setup(
         name="ledes-parser",
         description="A package for parsing LEDES format files",
         url="https://github.com/travisbashor/ledes-parser",
         author="Travis Bashor",
         author_email="travis.bashor@gmail.com",
-        version=app.__version__,
+        version=read_version(),
         packages=find_packages(exclude=["tests*"]),
         include_package_data=True,
-        package_data={"ledes_parser": ["grammars/**/*.lark"]},
-        install_requires=["lark-parser==0.12.0"],
+        package_data={"ledes_parser": ["grammars/**/*.lark", "transformers/**/*.py"]},
+        install_requires=["lark-parser==0.12.0", "lark==1.1.9"],
     )
 
 


### PR DESCRIPTION
In setup.py, I was getting the version number by importing ledes_parser (__init__.py) as app and grabbing `app.__version__` from it. That file imports lark, so it transitively made `lark` a setup-time dependency, which it isn't really.

Attempts to just set `setup_requires` in the setup file didn't work, so I hacked it to read the file as raw text, rather than import it.